### PR TITLE
Fix Docker Desktop build issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
             ${dockerImagePrefix}${dockerHubOrganization}${dockerOrgSeperator}
         </dockerCafDataProcessingOrg>
         <dockerProjectVersion>${dockerVersionSeperator}${project.version}</dockerProjectVersion>
-        <fabric8.docker.maven.version>0.28.0</fabric8.docker.maven.version>
+        <fabric8.docker.maven.version>0.37.0</fabric8.docker.maven.version>
         <homeDockerPrereleaseRegistry>saas-docker-prerelease.${corporateRepositoryManager}</homeDockerPrereleaseRegistry>
         <homeDockerReleaseRegistry>saas-docker-release.${corporateRepositoryManager}</homeDockerReleaseRegistry>
         <processingServiceContainerName>


### PR DESCRIPTION
Updating version of the Docker Maven Plugin to fix this error when building the project using Docker Desktop:

```
[ERROR] Failed to execute goal io.fabric8:docker-maven-plugin:0.28.0:start (start) on project worker-workflow-container: Execution start of goal io.fabric8:docker-maven-plugin:0.28.0:start failed: Index 0 out of bounds for length 0 -> [Help 1]
```