### PR TITLE
665078: Fix CAF_WMP_ENABLED parsing error

### DIFF
--- a/worker-workflow/src/main/resources/workflow-control.js
+++ b/worker-workflow/src/main/resources/workflow-control.js
@@ -296,7 +296,6 @@ function applyActionDetails(document, actionDetails, terminateOnFailure) {
 
 function isCafWmpEnabled() {
     var cafWmpEnabledString = System.getenv("CAF_WMP_ENABLED");
-    console.log("(RORY TEMP LOG) CAF_WMP_ENABLED: " + cafWmpEnabledString);
     return cafWmpEnabledString !== null && cafWmpEnabledString.toLowerCase() === "true";
 }
 

--- a/worker-workflow/src/main/resources/workflow-control.js
+++ b/worker-workflow/src/main/resources/workflow-control.js
@@ -155,7 +155,7 @@ function routeTask(rootDocument) {
                 rootDocument.getField('CAF_WORKFLOW_ACTION').add(action.name);
                 applyActionDetails(rootDocument, actionDetails, terminateOnFailure);
 
-                if (action.applyMessagePrioritization && System.getenv("CAF_WMP_ENABLED")) {
+                if (action.applyMessagePrioritization && isCafWmpEnabled()) {
                     var messageRouterSingleton =
                         Java.type("com.github.workerframework.workermessageprioritization.rerouting.MessageRouterSingleton");
                     messageRouterSingleton.init();
@@ -292,6 +292,12 @@ function applyActionDetails(document, actionDetails, terminateOnFailure) {
             scriptObjectAdded.install();
         }
     }
+}
+
+function isCafWmpEnabled() {
+    var cafWmpEnabledString = System.getenv("CAF_WMP_ENABLED");
+    console.log("(RORY TEMP LOG) CAF_WMP_ENABLED: " + cafWmpEnabledString);
+    return cafWmpEnabledString !== null && cafWmpEnabledString.toLowerCase() === "true";
 }
 
 function onAfterProcessDocument(e) {


### PR DESCRIPTION
`System.getenv("CAF_WMP_ENABLED")` returns a string, meaning the previous code was treating `"false"` as a JavaScript truthy value.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=665078