### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/worker-workflow-container/pom.xml
+++ b/worker-workflow-container/pom.xml
@@ -26,6 +26,7 @@
     </parent>
 
     <artifactId>worker-workflow-container</artifactId>
+    <name>worker-workflow-container</name>
     <packaging>pom</packaging>
 
     <!-- Properties for the worker. -->

--- a/worker-workflow-restclients/pom.xml
+++ b/worker-workflow-restclients/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>worker-workflow-restclients</artifactId>
+    <name>worker-workflow-restclients</name>
 
     <dependencies>
         <dependency>

--- a/worker-workflow-testing/pom.xml
+++ b/worker-workflow-testing/pom.xml
@@ -27,6 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-workflow-testing</artifactId>
+    <name>worker-workflow-testing</name>
 
     <dependencies>
         <dependency>

--- a/worker-workflow/pom.xml
+++ b/worker-workflow/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>worker-workflow</artifactId>
+    <name>worker-workflow</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210